### PR TITLE
Feature/stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,15 +22,15 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cmake"
@@ -58,20 +64,30 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -82,9 +98,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/mechpen/rterm"
 keywords = ["st", "terminal"]
 
 [dependencies]
-x11 = "2.0"
-nix = "0.18"
+x11 = "2"
+nix = "0.22"
 vte = "0.10"
 bitflags = "1.2"
 unicode-width = "0.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,9 +62,9 @@ impl App {
         let term = Term::new(cols, rows)?;
         Ok(App {
             win: Win::new(term.cols, term.rows, xoff, yoff, font)?,
-            term: term,
+            term,
             vte: Vte::new(),
-            log: log,
+            log,
         })
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,7 +85,7 @@ impl App {
 
             match select(None, Some(&mut rfds), Some(&mut wfds), None, None) {
                 Ok(_) => (),
-                Err(nix::Error::Sys(Errno::EINTR)) => continue,
+                Err(Errno::EINTR) => continue,
                 Err(err) => return Err(err.into()),
             }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -39,7 +39,7 @@ fn _main() -> Result<()> {
             i += 1;
             continue;
         }
-        if arg.starts_with("-") {
+        if arg.starts_with('-') {
             usage();
             return Err("invalid option".into());
         }
@@ -48,7 +48,7 @@ fn _main() -> Result<()> {
     let mut app = App::new(geometry, font, log)?;
     app.run()?;
 
-    return Ok(());
+    Ok(())
 }
 
 fn main() {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,10 +1,7 @@
 extern crate rterm;
 
+use rterm::{app::App, Result};
 use std::env;
-use rterm::{
-    app::App,
-    Result,
-};
 
 fn usage() {
     println!("usage: rterm [-v] [-g geometry] [-f font] [-o file]");

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,5 +1,7 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
-
+// This covers the initial 16 colors, it also support 256 and true color modes
+// and a palette of of the colors from 16-255 are generated (see Win::new() in
+// win.rs).  The foreground/background and cursor get there own 'slots' after
+// the 256 color palette.
 pub const COLOR_NAMES: &[&str] = &[
     /* 8 normal colors */
     "black", "red3", "green3", "yellow3", "blue2", "magenta3", "cyan3", "gray90",
@@ -7,13 +9,7 @@ pub const COLOR_NAMES: &[&str] = &[
     "gray50", "red", "green", "yellow", "#5c5cff", "magenta", "cyan", "white",
 ];
 
-static FG_COLOR: AtomicUsize = AtomicUsize::new(7);
-static BG_COLOR: AtomicUsize = AtomicUsize::new(0);
-
-pub fn fg_color() -> usize {
-    FG_COLOR.load(Ordering::Relaxed)
-}
-
-pub fn bg_color() -> usize {
-    BG_COLOR.load(Ordering::Relaxed)
-}
+pub const FG_COLOR: usize = 258;
+pub const BG_COLOR: usize = 259;
+pub const FG_COLOR_NAME: &str = "grey90";
+pub const BG_COLOR_NAME: &str = "black";

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,27 +1,10 @@
-use std::sync::atomic::{
-    AtomicUsize,
-    Ordering,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub const COLOR_NAMES: &[&str] = &[
     /* 8 normal colors */
-    "black",
-    "red3",
-    "green3",
-    "yellow3",
-    "blue2",
-    "magenta3",
-    "cyan3",
-    "gray90",
+    "black", "red3", "green3", "yellow3", "blue2", "magenta3", "cyan3", "gray90",
     /* 8 bright colors */
-    "gray50",
-    "red",
-    "green",
-    "yellow",
-    "#5c5cff",
-    "magenta",
-    "cyan",
-    "white",
+    "gray50", "red", "green", "yellow", "#5c5cff", "magenta", "cyan", "white",
 ];
 
 static FG_COLOR: AtomicUsize = AtomicUsize::new(7);

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,8 +1,5 @@
+use crate::glyph::{blank_glyph, Glyph};
 use std::mem;
-use crate::glyph::{
-    Glyph,
-    blank_glyph,
-};
 
 pub struct Cursor {
     pub glyph: Glyph,
@@ -21,8 +18,10 @@ impl Cursor {
         Cursor {
             glyph: blank_glyph(),
             wrap_next: false,
-            x: 0, y: 0,
-            saved_x: 0, saved_y: 0,
+            x: 0,
+            y: 0,
+            saved_x: 0,
+            saved_y: 0,
         }
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,6 +1,7 @@
 use crate::glyph::{blank_glyph, Glyph};
 use std::mem;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Cursor {
     pub glyph: Glyph,
     pub x: usize,
@@ -8,9 +9,6 @@ pub struct Cursor {
     // When cursor is at the right edge of the terminal, it does
     // not wrap to new line until one more character is input.
     pub wrap_next: bool,
-
-    saved_x: usize,
-    saved_y: usize,
 }
 
 impl Cursor {
@@ -20,22 +18,10 @@ impl Cursor {
             wrap_next: false,
             x: 0,
             y: 0,
-            saved_x: 0,
-            saved_y: 0,
         }
     }
 
     pub fn reset(&mut self) {
         let _ = mem::replace(self, Cursor::new());
-    }
-
-    pub fn save_pos(&mut self) {
-        self.saved_x = self.x;
-        self.saved_y = self.y;
-    }
-
-    pub fn load_pos(&mut self) {
-        self.x = self.saved_x;
-        self.y = self.saved_y;
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,8 +1,8 @@
-use std::os::raw::c_int;
-use std::ffi::CString;
-use crate::x11_wrapper as x11;
 use crate::glyph::GlyphAttr;
+use crate::x11_wrapper as x11;
 use crate::Result;
+use std::ffi::CString;
+use std::os::raw::c_int;
 
 pub struct Font {
     font: x11::XftFont,
@@ -22,30 +22,35 @@ impl Font {
         let slant = CString::new("slant").unwrap();
         let weight = CString::new("weight").unwrap();
 
-	x11::FcPatternDel(pattern, &slant);
-	x11::FcPatternAddInteger(pattern, &slant, x11::FC_SLANT_ITALIC);
+        x11::FcPatternDel(pattern, &slant);
+        x11::FcPatternAddInteger(pattern, &slant, x11::FC_SLANT_ITALIC);
         let matched = x11::XftFontMatch(dpy, scr, pattern)?;
         let ifont = x11::XftFontOpenPattern(dpy, matched)?;
         x11::FcPatternDestroy(matched);
 
-	x11::FcPatternDel(pattern, &weight);
-	x11::FcPatternAddInteger(pattern, &weight, x11::FC_WEIGHT_BOLD);
+        x11::FcPatternDel(pattern, &weight);
+        x11::FcPatternAddInteger(pattern, &weight, x11::FC_WEIGHT_BOLD);
         let matched = x11::XftFontMatch(dpy, scr, pattern)?;
         let ibfont = x11::XftFontOpenPattern(dpy, matched)?;
         x11::FcPatternDestroy(matched);
 
-	x11::FcPatternDel(pattern, &slant);
-	x11::FcPatternAddInteger(pattern, &slant, x11::FC_SLANT_ROMAN);
+        x11::FcPatternDel(pattern, &slant);
+        x11::FcPatternAddInteger(pattern, &slant, x11::FC_SLANT_ROMAN);
         let matched = x11::XftFontMatch(dpy, scr, pattern)?;
         let bfont = x11::XftFontOpenPattern(dpy, matched)?;
         x11::FcPatternDestroy(matched);
 
         x11::FcPatternDestroy(pattern);
-        Ok(Self { font, bfont, ifont, ibfont })
+        Ok(Self {
+            font,
+            bfont,
+            ifont,
+            ibfont,
+        })
     }
 
     pub fn get(&self, attr: GlyphAttr) -> x11::XftFont {
-        if attr.contains(GlyphAttr::BOLD|GlyphAttr::ITALIC) {
+        if attr.contains(GlyphAttr::BOLD | GlyphAttr::ITALIC) {
             return self.ibfont;
         }
         if attr.contains(GlyphAttr::BOLD) {

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,4 +1,4 @@
-use crate::color::{bg_color, fg_color};
+use crate::color::{BG_COLOR, FG_COLOR};
 use bitflags::bitflags;
 use std::mem;
 
@@ -38,17 +38,17 @@ impl GlyphProp {
     }
 
     pub fn reset(&mut self) {
-        self.fg = fg_color();
-        self.bg = bg_color();
+        self.fg = FG_COLOR;
+        self.bg = BG_COLOR;
         self.attr -= GlyphAttr::FONT_MASK;
     }
 
     pub fn reset_fg(&mut self) {
-        self.fg = fg_color();
+        self.fg = FG_COLOR;
     }
 
     pub fn reset_bg(&mut self) {
-        self.bg = bg_color();
+        self.bg = BG_COLOR;
     }
 
     pub fn resolve(&self, reverse: bool) -> Self {
@@ -91,5 +91,5 @@ impl Glyph {
 }
 
 pub fn blank_glyph() -> Glyph {
-    Glyph::new(' ', fg_color(), bg_color(), GlyphAttr::empty())
+    Glyph::new(' ', FG_COLOR, BG_COLOR, GlyphAttr::empty())
 }

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -1,9 +1,6 @@
+use crate::color::{bg_color, fg_color};
 use bitflags::bitflags;
 use std::mem;
-use crate::color::{
-    fg_color,
-    bg_color,
-};
 
 bitflags! {
     pub struct GlyphAttr: u16 {
@@ -79,7 +76,10 @@ pub struct Glyph {
 
 impl Glyph {
     pub fn new(c: char, fg: usize, bg: usize, attr: GlyphAttr) -> Self {
-        Self { c, prop: GlyphProp::new(fg, bg, attr) }
+        Self {
+            c,
+            prop: GlyphProp::new(fg, bg, attr),
+        }
     }
 
     pub fn clear(&mut self, cursor: Glyph) {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,12 +1,12 @@
-use x11::xlib::*;
-use x11::keysym::*;
-use std::os::raw::*;
 use crate::win::WinMode;
+use std::os::raw::*;
+use x11::keysym::*;
+use x11::xlib::*;
 
-const XK_ANY_MOD:    u32 = u32::MAX;
-const XK_NO_MOD:     u32 = 0;
-const XK_SWITCH_MOD: u32 = 1<<13;
-const IGNORE_MOD:    u32 = Mod2Mask | XK_SWITCH_MOD;
+const XK_ANY_MOD: u32 = u32::MAX;
+const XK_NO_MOD: u32 = 0;
+const XK_SWITCH_MOD: u32 = 1 << 13;
+const IGNORE_MOD: u32 = Mod2Mask | XK_SWITCH_MOD;
 
 struct Key {
     k: c_uint,
@@ -33,7 +33,7 @@ macro_rules! make_keys {
     }
 }
 
-const KEYS: &[Key] = make_keys!{
+const KEYS: &[Key] = make_keys! {
     /* keysym           mask            string      appkeypad appcursor */
     { XK_KP_Home,       ShiftMask,      b"\x1B[2J",       0,   -1},
     { XK_KP_Home,       ShiftMask,      b"\x1B[1;2H",     0,    1},
@@ -246,9 +246,7 @@ const KEYS: &[Key] = make_keys!{
     { XK_F35,           XK_NO_MOD,      b"\x1B[23;5~",    0,    0},
 };
 
-pub fn map_key(
-    k: KeySym, state: c_uint, mode: &WinMode
-) -> Option<&'static [u8]> {
+pub fn map_key(k: KeySym, state: c_uint, mode: &WinMode) -> Option<&'static [u8]> {
     let k = k as c_uint;
     if k & 0xFFFF < 0xFD00 {
         return None;

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -272,20 +272,16 @@ pub fn map_key(k: KeySym, state: c_uint, mode: &WinMode) -> Option<&'static [u8]
             if key.appkeypad < 0 {
                 continue;
             }
-        } else {
-            if key.appkeypad > 0 {
-                continue;
-            }
+        } else if key.appkeypad > 0 {
+            continue;
         }
 
         if appcursor {
             if key.appcursor < 0 {
                 continue;
             }
-        } else {
-            if key.appcursor > 0 {
-                continue;
-            }
+        } else if key.appcursor > 0 {
+            continue;
         }
 
         return Some(key.s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,27 +5,29 @@ pub struct Error {
 
 impl<T: std::fmt::Display> std::convert::From<T> for Error {
     fn from(e: T) -> Self {
-        Error{ msg: format!("{}", e) }
+        Error {
+            msg: format!("{}", e),
+        }
     }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-mod x11_wrapper;
-mod point;
-mod glyph;
-mod utils;
 mod charset;
-mod shortcut;
-mod keymap;
-mod snap;
-mod font;
-mod shell;
-mod cursor;
 mod color;
-mod term;
-mod win;
-mod vte;
+mod cursor;
+mod font;
+mod glyph;
+mod keymap;
+mod point;
 mod pty;
+mod shell;
+mod shortcut;
+mod snap;
+mod term;
+mod utils;
+mod vte;
+mod win;
+mod x11_wrapper;
 
 pub mod app;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -23,7 +23,7 @@ impl Pty {
         let ForkptyResult {
             master,
             fork_result,
-        } = forkpty(None, None)?;
+        } = unsafe { forkpty(None, None)? };
         let child = match fork_result {
             ForkResult::Parent { child } => child,
             ForkResult::Child => {
@@ -61,7 +61,7 @@ impl Pty {
     pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
         match read(self.master_fd, buf) {
             Ok(n) => Ok(n),
-            Err(nix::Error::Sys(Errno::EIO)) => Ok(0),
+            Err(Errno::EIO) => Ok(0),
             Err(err) => Err(err.into()),
         }
     }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -62,7 +62,7 @@ impl Pty {
         match read(self.master_fd, buf) {
             Ok(n) => Ok(n),
             Err(nix::Error::Sys(Errno::EIO)) => Ok(0),
-            Err(err) => return Err(err.into()),
+            Err(err) => Err(err.into()),
         }
     }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,25 +1,14 @@
-use nix::unistd::{
-    read,
-    write,
-    ForkResult,
-    Pid,
-};
-use nix::pty::{
-    forkpty,
-    ForkptyResult,
-};
-use nix::sys::signal::{
-    kill,
-    Signal,
-};
-use nix::errno::Errno;
-use nix::libc;
-use nix::ioctl_write_ptr_bad;
-use std::os::unix::io::RawFd;
-use std::convert::TryFrom;
-use std::collections::VecDeque;
 use crate::shell::exec_shell;
 use crate::Result;
+use nix::errno::Errno;
+use nix::ioctl_write_ptr_bad;
+use nix::libc;
+use nix::pty::{forkpty, ForkptyResult};
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::{read, write, ForkResult, Pid};
+use std::collections::VecDeque;
+use std::convert::TryFrom;
+use std::os::unix::io::RawFd;
 
 ioctl_write_ptr_bad!(resizepty, libc::TIOCSWINSZ, libc::winsize);
 
@@ -31,7 +20,10 @@ pub struct Pty {
 
 impl Pty {
     pub fn new() -> Result<Self> {
-        let ForkptyResult { master, fork_result } = forkpty(None, None)?;
+        let ForkptyResult {
+            master,
+            fork_result,
+        } = forkpty(None, None)?;
         let child = match fork_result {
             ForkResult::Parent { child } => child,
             ForkResult::Child => {
@@ -56,7 +48,9 @@ impl Pty {
             ws_xpixel: 0,
             ws_ypixel: 0,
         };
-        unsafe { resizepty(self.master_fd, &ws)?; }
+        unsafe {
+            resizepty(self.master_fd, &ws)?;
+        }
         Ok(())
     }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -9,7 +9,8 @@ use std::process::exit;
 
 fn _exec_shell() -> Result<()> {
     let user = User::from_uid(Uid::current())?.unwrap();
-    let shell = env::var_os("SHELL").unwrap_or(user.shell.into());
+    let shell_default = &user.shell;
+    let shell = env::var_os("SHELL").unwrap_or_else(|| shell_default.into());
 
     env::remove_var("COLUMNS");
     env::remove_var("LINES");

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,18 +1,11 @@
-use nix::unistd::{
-    Uid,
-    User,
-};
-use nix::sys::signal::{
-    signal,
-    Signal,
-    SigHandler,
-};
+use crate::Result;
+use nix::sys::signal::{signal, SigHandler, Signal};
 use nix::unistd::execvp;
+use nix::unistd::{Uid, User};
 use std::env;
-use std::process::exit;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStringExt;
-use crate::Result;
+use std::process::exit;
 
 fn _exec_shell() -> Result<()> {
     let user = User::from_uid(Uid::current())?.unwrap();
@@ -23,16 +16,16 @@ fn _exec_shell() -> Result<()> {
     env::remove_var("TERMCAP");
 
     env::set_var("LOGNAME", &user.name);
-    env::set_var("USER",    &user.name);
-    env::set_var("HOME",    &user.dir);
-    env::set_var("SHELL",   &shell);
-    env::set_var("TERM",    "xterm");
+    env::set_var("USER", &user.name);
+    env::set_var("HOME", &user.dir);
+    env::set_var("SHELL", &shell);
+    env::set_var("TERM", "xterm");
 
     unsafe {
         signal(Signal::SIGCHLD, SigHandler::SigDfl)?;
         signal(Signal::SIGCHLD, SigHandler::SigDfl)?;
-        signal(Signal::SIGHUP,  SigHandler::SigDfl)?;
-        signal(Signal::SIGINT,  SigHandler::SigDfl)?;
+        signal(Signal::SIGHUP, SigHandler::SigDfl)?;
+        signal(Signal::SIGINT, SigHandler::SigDfl)?;
         signal(Signal::SIGQUIT, SigHandler::SigDfl)?;
         signal(Signal::SIGTERM, SigHandler::SigDfl)?;
         signal(Signal::SIGALRM, SigHandler::SigDfl)?;

--- a/src/shortcut.rs
+++ b/src/shortcut.rs
@@ -1,8 +1,8 @@
-use x11::xlib::*;
-use x11::keysym::*;
-use std::os::raw::*;
-use crate::win::Win;
 use crate::term::Term;
+use crate::win::Win;
+use std::os::raw::*;
+use x11::keysym::*;
+use x11::xlib::*;
 
 #[derive(Clone, Copy)]
 pub enum Function {
@@ -37,7 +37,7 @@ macro_rules! make_shortcuts {
     }
 }
 
-const SHORTCUTS: &[Shortcut] = make_shortcuts!{
+const SHORTCUTS: &[Shortcut] = make_shortcuts! {
     /* mask                  keysym          function */
     { ShiftMask,             XK_Insert,      Function::Paste },
 };

--- a/src/snap.rs
+++ b/src/snap.rs
@@ -1,7 +1,4 @@
-use std::time::{
-    Instant,
-    Duration,
-};
+use std::time::{Duration, Instant};
 
 const WORD_DELIMITERS: &str = " ()[]{}<>`~!@#$%^&*-=+\\|;:'\",.?/";
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -514,10 +514,8 @@ impl Term {
         if p.x < self.cols - 1 {
             return Some(Point::new(p.x + 1, p.y));
         }
-        if p.y < self.rows - 1 {
-            if self.lines[p.y][p.x].prop.attr.contains(GlyphAttr::WRAP) {
-                return Some(Point::new(0, p.y + 1));
-            }
+        if p.y < self.rows - 1 && self.lines[p.y][p.x].prop.attr.contains(GlyphAttr::WRAP) {
+            return Some(Point::new(0, p.y + 1));
         }
         None
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use std::cmp;
 use crate::Result;
+use std::cmp;
 
 #[inline]
 pub fn is_between<T: PartialOrd>(x: T, a: T, b: T) -> bool {
@@ -13,7 +13,11 @@ pub fn limit<T: Ord>(x: T, min: T, max: T) -> T {
 
 #[inline]
 pub fn sort_pair<T: Ord>(a: T, b: T) -> (T, T) {
-    if a > b { (b, a) } else { (a, b) }
+    if a > b {
+        (b, a)
+    } else {
+        (a, b)
+    }
 }
 
 #[inline]

--- a/src/vte.rs
+++ b/src/vte.rs
@@ -270,10 +270,8 @@ impl<'a> Perform for Performer<'a> {
                 win.set_mode(WinMode::APPKEYPAD, false)
             }
             (b'\\', None) =>
-            // ST -- String Terminator
-            {
-                ()
-            }
+                // ST -- String Terminator
+                {}
             _ => println!("unknown esc {:?} {}", intermediate, byte as char),
         }
     }

--- a/src/vte.rs
+++ b/src/vte.rs
@@ -222,11 +222,26 @@ impl<'a> Performer<'a> {
                         self.win.set_mode(WinMode::MOUSESGR, val);
                     }
                     1034 => self.win.set_mode(WinMode::EIGHT_BIT, val),
-                    1048 => {
-                        if val {
-                            self.term.save_cursor();
-                        } else {
-                            self.term.load_cursor();
+                    47 | 1047 => {
+                        /* swap screen */
+                        let alt = self.term.in_mode(TermMode::ALTSCREEN);
+                        if alt {
+                            self.term.clear_region(0..self.term.cols, 0..self.term.rows);
+                        }
+                        if val ^ alt {
+                            self.term.swap_screen()
+                        }
+                    }
+                    1048 => self.term.save_load_cursor(val),
+                    1049 => {
+                        /* swap screen & set/restore cursor as xterm */
+                        self.term.save_load_cursor(val);
+                        let alt = self.term.in_mode(TermMode::ALTSCREEN);
+                        if alt {
+                            self.term.clear_region(0..self.term.cols, 0..self.term.rows);
+                        }
+                        if val ^ alt {
+                            self.term.swap_screen()
                         }
                     }
                     _ => (),

--- a/src/vte.rs
+++ b/src/vte.rs
@@ -183,6 +183,44 @@ impl<'a> Performer<'a> {
                     {
                         self.win.set_mode(WinMode::HIDE, !val)
                     }
+                    9 =>
+                    /* X10 mouse compatibility mode */
+                    {
+                        self.win.set_pointer_motion(false);
+                        self.win.set_mode(WinMode::MOUSE, false);
+                        self.win.set_mode(WinMode::MOUSEX10, val);
+                    }
+                    1000 =>
+                    /* 1000: report button press */
+                    {
+                        self.win.set_pointer_motion(false);
+                        self.win.set_mode(WinMode::MOUSE, false);
+                        self.win.set_mode(WinMode::MOUSEBTN, val);
+                    }
+                    1002 =>
+                    /* 1002: report motion on button press */
+                    {
+                        self.win.set_pointer_motion(false);
+                        self.win.set_mode(WinMode::MOUSE, false);
+                        self.win.set_mode(WinMode::MOUSEMOTION, val);
+                    }
+                    1003 =>
+                    /* 1003: enable all mouse motions */
+                    {
+                        self.win.set_pointer_motion(val);
+                        self.win.set_mode(WinMode::MOUSE, false);
+                        self.win.set_mode(WinMode::MOUSEMANY, val);
+                    }
+                    1004 =>
+                    /* 1004: send focus events to tty */
+                    {
+                        self.win.set_mode(WinMode::FOCUS, val);
+                    }
+                    1006 =>
+                    /* 1006: extended reporting mode */
+                    {
+                        self.win.set_mode(WinMode::MOUSESGR, val);
+                    }
                     1034 => self.win.set_mode(WinMode::EIGHT_BIT, val),
                     1048 => {
                         if val {

--- a/src/win.rs
+++ b/src/win.rs
@@ -141,7 +141,7 @@ impl Win {
             visible: true,
             mode: WinMode::empty(),
 
-            sel_type: sel_type,
+            sel_type,
             sel_snap: Snap::new(),
             sel_text: None,
 

--- a/src/x11_wrapper.rs
+++ b/src/x11_wrapper.rs
@@ -1,18 +1,15 @@
 #![allow(non_snake_case)]
 
-use x11::xlib;
-use x11::xft;
+use crate::Result;
 use fontconfig::fontconfig as fc;
-use std::mem;
-use std::os::raw::*;
+use std::convert::TryInto;
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::convert::TryInto;
-use std::ptr::{
-    null,
-    null_mut,
-};
-use crate::Result;
+use std::mem;
+use std::os::raw::*;
+use std::ptr::{null, null_mut};
+use x11::xft;
+use x11::xlib;
 
 pub const XC_XTERM: c_uint = 152;
 
@@ -22,39 +19,39 @@ pub use xlib::XA_PRIMARY;
 pub use xlib::CurrentTime as CURRENT_TIME;
 
 pub use xlib::Atom;
-pub use xlib::Window;
 pub use xlib::Colormap;
-pub use xlib::Pixmap;
-pub use xlib::GC;
 pub use xlib::Cursor;
-pub use xlib::XSetWindowAttributes;
-pub use xlib::XGCValues;
-pub use xlib::XEvent;
+pub use xlib::False;
 pub use xlib::KeySym;
+pub use xlib::Pixmap;
 pub use xlib::Time;
 pub use xlib::True;
-pub use xlib::False;
+pub use xlib::Window;
+pub use xlib::XEvent;
+pub use xlib::XGCValues;
+pub use xlib::XSetWindowAttributes;
+pub use xlib::GC;
 
-pub use xlib::InputOutput as INPUT_OUTPUT;
 pub use xlib::GCGraphicsExposures as GC_GRAPHICS_EXPOSURES;
+pub use xlib::InputOutput as INPUT_OUTPUT;
 pub use xlib::PropModeReplace as PROP_MODE_REPLACE;
 
 pub use xlib::CWBackPixel as CW_BACK_PIXEL;
 pub use xlib::CWColormap as CW_COLOR_MAP;
 pub use xlib::CWEventMask as CW_EVENT_MASK;
 
-pub use xlib::KeyPressMask as KEY_PRESS_MASK;
-pub use xlib::ExposureMask as EXPOSURE_MASK;
-pub use xlib::VisibilityChangeMask as VISIBILITY_CHANGE_MASK;
-pub use xlib::StructureNotifyMask as STRUCTURE_NOTIFY_MASK;
 pub use xlib::ButtonMotionMask as BUTTON_MOTION_MASK;
 pub use xlib::ButtonPressMask as BUTTON_PRESS_MASK;
 pub use xlib::ButtonReleaseMask as BUTTON_RELEASE_MASK;
+pub use xlib::ExposureMask as EXPOSURE_MASK;
+pub use xlib::KeyPressMask as KEY_PRESS_MASK;
+pub use xlib::StructureNotifyMask as STRUCTURE_NOTIFY_MASK;
+pub use xlib::VisibilityChangeMask as VISIBILITY_CHANGE_MASK;
 
-pub use xlib::XKeyEvent;
-pub use xlib::Mod1Mask as MOD1_MASK;
 pub use xlib::KeyPress as KEY_PRESS;
 pub use xlib::KeyRelease as KEY_RELEASE;
+pub use xlib::Mod1Mask as MOD1_MASK;
+pub use xlib::XKeyEvent;
 
 pub use xlib::ButtonPress as BUTTON_PRESS;
 pub use xlib::ButtonRelease as BUTTON_RELEASE;
@@ -65,12 +62,12 @@ pub use xlib::XMotionEvent;
 
 pub use xlib::Expose as EXPOSE;
 
+pub use xlib::VisibilityFullyObscured;
 pub use xlib::VisibilityNotify as VISIBILITY_NOTIFY;
 pub use xlib::XVisibilityEvent;
-pub use xlib::VisibilityFullyObscured;
 
-pub use xlib::UnmapNotify as UNMAP_NOTIFY;
 pub use xlib::MapNotify as MAP_NOTIFY;
+pub use xlib::UnmapNotify as UNMAP_NOTIFY;
 
 pub use xlib::ConfigureNotify as CONFIGURE_NOTIFY;
 pub use xlib::XConfigureEvent;
@@ -97,7 +94,9 @@ pub type XftDraw = *mut xft::XftDraw;
 pub type FcPattern = *mut xft::FcPattern;
 
 fn cast<T, V>(v: V) -> T
-where V: TryInto<T>, <V as TryInto<T>>::Error: std::fmt::Debug
+where
+    V: TryInto<T>,
+    <V as TryInto<T>>::Error: std::fmt::Debug,
 {
     v.try_into().unwrap()
 }
@@ -147,44 +146,68 @@ pub fn XRootWindow(dpy: Display, scr: c_int) -> Window {
 }
 
 pub fn XCreateWindow(
-    dpy: Display, parent: Window,
-    x: usize, y :usize, width: usize, height: usize,
-    border: usize, depth: c_uint, class: c_int, vis: Visual,
-    value_mask: c_ulong, values: &mut XSetWindowAttributes,
+    dpy: Display,
+    parent: Window,
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    border: usize,
+    depth: c_uint,
+    class: c_int,
+    vis: Visual,
+    value_mask: c_ulong,
+    values: &mut XSetWindowAttributes,
 ) -> Window {
     unsafe {
         xlib::XCreateWindow(
-            dpy, parent,
-            cast(x), cast(y), cast(width), cast(height),
-            cast(border), cast(depth), cast(class), vis,
-            value_mask, values
+            dpy,
+            parent,
+            cast(x),
+            cast(y),
+            cast(width),
+            cast(height),
+            cast(border),
+            cast(depth),
+            cast(class),
+            vis,
+            value_mask,
+            values,
         )
     }
 }
 
 pub fn XStoreName(dpy: Display, win: Window, name: &str) {
     let name = CString::new(name).unwrap();
-    unsafe { xlib::XStoreName(dpy, win, name.as_ptr() as *mut _); }
+    unsafe {
+        xlib::XStoreName(dpy, win, name.as_ptr() as *mut _);
+    }
 }
 
-pub fn XCreateGC(
-    dpy: Display, d: c_ulong, value_mask: u32, values: &mut XGCValues
-) -> GC {
+pub fn XCreateGC(dpy: Display, d: c_ulong, value_mask: u32, values: &mut XGCValues) -> GC {
     unsafe { xlib::XCreateGC(dpy, d, cast(value_mask), values) }
 }
 
 pub fn XCreatePixmap(
-    dpy: Display, d: c_ulong, width: usize, height: usize, depth: c_uint
+    dpy: Display,
+    d: c_ulong,
+    width: usize,
+    height: usize,
+    depth: c_uint,
 ) -> Pixmap {
     unsafe { xlib::XCreatePixmap(dpy, d, width as u32, height as u32, depth) }
 }
 
 pub fn XFreePixmap(dpy: Display, pixmap: c_ulong) {
-    unsafe { xlib::XFreePixmap(dpy, pixmap); }
+    unsafe {
+        xlib::XFreePixmap(dpy, pixmap);
+    }
 }
 
 pub fn XFree(data: *mut c_void) {
-    unsafe { xlib::XFree(data); }
+    unsafe {
+        xlib::XFree(data);
+    }
 }
 
 pub fn XCreateFontCursor(dpy: Display, shape: c_uint) -> Cursor {
@@ -192,7 +215,9 @@ pub fn XCreateFontCursor(dpy: Display, shape: c_uint) -> Cursor {
 }
 
 pub fn XDefineCursor(dpy: Display, win: Window, cursor: Cursor) {
-    unsafe { xlib::XDefineCursor(dpy, win, cursor); }
+    unsafe {
+        xlib::XDefineCursor(dpy, win, cursor);
+    }
 }
 
 pub fn XInternAtom(dpy: Display, name: &str, only_if_exists: c_int) -> Atom {
@@ -202,44 +227,66 @@ pub fn XInternAtom(dpy: Display, name: &str, only_if_exists: c_int) -> Atom {
 
 pub fn XSetWMProtocols(dpy: Display, win: Window, protocols: &mut [Atom]) {
     unsafe {
-        xlib::XSetWMProtocols(
-            dpy, win, protocols.as_mut_ptr(), cast(protocols.len())
-        );
+        xlib::XSetWMProtocols(dpy, win, protocols.as_mut_ptr(), cast(protocols.len()));
     }
 }
 
 pub fn XMapWindow(dpy: Display, win: Window) {
-    unsafe { xlib::XMapWindow(dpy, win); }
+    unsafe {
+        xlib::XMapWindow(dpy, win);
+    }
 }
 
 pub fn XDestroyWindow(dpy: Display, win: Window) {
-    unsafe { xlib::XDestroyWindow(dpy, win); }
+    unsafe {
+        xlib::XDestroyWindow(dpy, win);
+    }
 }
 
 pub fn XCloseDisplay(dpy: Display) {
-    unsafe { xlib::XCloseDisplay(dpy); }
+    unsafe {
+        xlib::XCloseDisplay(dpy);
+    }
 }
 
 pub fn XCopyArea(
-    dpy: Display, src: c_ulong, dst: c_ulong, gc: GC,
-    src_x: usize, src_y: usize, width: usize, height: usize,
-    dst_x: usize, dst_y: usize,
+    dpy: Display,
+    src: c_ulong,
+    dst: c_ulong,
+    gc: GC,
+    src_x: usize,
+    src_y: usize,
+    width: usize,
+    height: usize,
+    dst_x: usize,
+    dst_y: usize,
 ) {
     unsafe {
         xlib::XCopyArea(
-            dpy, src, dst, gc,
-            cast(src_x), cast(src_y), cast(width), cast(height),
-            cast(dst_x), cast(dst_y),
+            dpy,
+            src,
+            dst,
+            gc,
+            cast(src_x),
+            cast(src_y),
+            cast(width),
+            cast(height),
+            cast(dst_x),
+            cast(dst_y),
         );
     }
 }
 
 pub fn XFlush(dpy: Display) {
-    unsafe { xlib::XFlush(dpy); }
+    unsafe {
+        xlib::XFlush(dpy);
+    }
 }
 
 pub fn XSync(dpy: Display, discard: c_int) {
-    unsafe { xlib::XSync(dpy, discard); }
+    unsafe {
+        xlib::XSync(dpy, discard);
+    }
 }
 
 pub fn XNextEvent(dpy: Display) -> XEvent {
@@ -266,51 +313,86 @@ pub fn XLookupString(event: &mut XKeyEvent, buf: &mut [u8]) -> (KeySym, usize) {
     let mut ksym: KeySym = 0;
     let len = unsafe {
         xlib::XLookupString(
-            event, buf.as_mut_ptr() as *mut _, cast(buf.len()),
-            &mut ksym, null_mut()
+            event,
+            buf.as_mut_ptr() as *mut _,
+            cast(buf.len()),
+            &mut ksym,
+            null_mut(),
         )
     };
     (ksym, cast(len))
 }
 
 pub fn XGetWindowProperty(
-    dpy: Display, win: Window, property: c_ulong,
-    ofs: c_long, length: c_long, delete: c_int, req_type: c_ulong,
-    ret_type: *mut Atom, ret_format: *mut c_int, ret_nitems: *mut c_ulong,
-    nbytes_more: *mut c_ulong, ret_props: *mut *mut c_uchar
+    dpy: Display,
+    win: Window,
+    property: c_ulong,
+    ofs: c_long,
+    length: c_long,
+    delete: c_int,
+    req_type: c_ulong,
+    ret_type: *mut Atom,
+    ret_format: *mut c_int,
+    ret_nitems: *mut c_ulong,
+    nbytes_more: *mut c_ulong,
+    ret_props: *mut *mut c_uchar,
 ) -> c_int {
     unsafe {
         xlib::XGetWindowProperty(
-            dpy, win, property, ofs, length, delete, req_type,
-            ret_type, ret_format, ret_nitems, nbytes_more, ret_props,
+            dpy,
+            win,
+            property,
+            ofs,
+            length,
+            delete,
+            req_type,
+            ret_type,
+            ret_format,
+            ret_nitems,
+            nbytes_more,
+            ret_props,
         )
     }
 }
 
 pub fn XChangeProperty(
-    dpy: Display, win: Window, property: c_ulong, property_type: c_ulong,
-    format: c_int, mode: c_int, data: *const c_uchar, nitems: usize,
+    dpy: Display,
+    win: Window,
+    property: c_ulong,
+    property_type: c_ulong,
+    format: c_int,
+    mode: c_int,
+    data: *const c_uchar,
+    nitems: usize,
 ) -> c_int {
     unsafe {
         xlib::XChangeProperty(
-            dpy, win, property, property_type, format, mode, data, cast(nitems),
+            dpy,
+            win,
+            property,
+            property_type,
+            format,
+            mode,
+            data,
+            cast(nitems),
         )
     }
 }
 
 pub fn XSendEvent(
-    dpy: Display, win: Window, propagate: c_int,
-    mask: c_long, event: *mut XEvent
+    dpy: Display,
+    win: Window,
+    propagate: c_int,
+    mask: c_long,
+    event: *mut XEvent,
 ) -> c_int {
-    unsafe {
-        xlib::XSendEvent(dpy, win, propagate, mask, event)
-    }
+    unsafe { xlib::XSendEvent(dpy, win, propagate, mask, event) }
 }
 
-pub fn XSetSelectionOwner(
-    dpy: Display, selection: Atom, win: Window, time: Time
-) {
-    unsafe { xlib::XSetSelectionOwner(dpy, selection, win, time); }
+pub fn XSetSelectionOwner(dpy: Display, selection: Atom, win: Window, time: Time) {
+    unsafe {
+        xlib::XSetSelectionOwner(dpy, selection, win, time);
+    }
 }
 
 pub fn XGetSelectionOwner(dpy: Display, selection: Atom) -> Window {
@@ -318,34 +400,30 @@ pub fn XGetSelectionOwner(dpy: Display, selection: Atom) -> Window {
 }
 
 pub fn XConvertSelection(
-    dpy: Display, selection: Atom, target: Atom,
-    property: Atom, requester: Window, time: Time
+    dpy: Display,
+    selection: Atom,
+    target: Atom,
+    property: Atom,
+    requester: Window,
+    time: Time,
 ) {
     unsafe {
-        xlib::XConvertSelection(
-            dpy, selection, target, property, requester, time
-        );
+        xlib::XConvertSelection(dpy, selection, target, property, requester, time);
     }
 }
 
 pub fn XftNameParse(name: &str) -> Result<FcPattern> {
     let name = CString::new(name).unwrap();
-    let pattern = unsafe {
-        xft::XftNameParse(name.as_ptr() as *const _)
-    };
+    let pattern = unsafe { xft::XftNameParse(name.as_ptr() as *const _) };
     if pattern == null_mut() {
         return Err("can't parse font name".into());
     }
     Ok(pattern)
 }
 
-pub fn XftFontMatch(
-    dpy: Display, scr: c_int, pattern: FcPattern
-) -> Result<FcPattern> {
+pub fn XftFontMatch(dpy: Display, scr: c_int, pattern: FcPattern) -> Result<FcPattern> {
     let mut result = xft::FcResult::NoMatch;
-    let pattern = unsafe {
-        xft::XftFontMatch(dpy, scr, pattern, &mut result)
-    };
+    let pattern = unsafe { xft::XftFontMatch(dpy, scr, pattern, &mut result) };
     if pattern == null_mut() {
         return Err("can't match font".into());
     }
@@ -368,9 +446,7 @@ pub fn font_ascent(font: XftFont) -> usize {
     unsafe { cast((*font).ascent) }
 }
 
-pub fn XftColorAllocName(
-    dpy: Display, vis: Visual, cmap: Colormap, name: &str
-) -> XftColor {
+pub fn XftColorAllocName(dpy: Display, vis: Visual, cmap: Colormap, name: &str) -> XftColor {
     let mut col = mem::MaybeUninit::uninit();
     let name = CString::new(name).unwrap();
     unsafe {
@@ -379,28 +455,33 @@ pub fn XftColorAllocName(
     }
 }
 
-pub fn XftDrawCreate(
-    dpy: Display, d: c_ulong, vis: Visual, cmap: c_ulong
-) -> XftDraw {
+pub fn XftDrawCreate(dpy: Display, d: c_ulong, vis: Visual, cmap: c_ulong) -> XftDraw {
     unsafe { xft::XftDrawCreate(dpy, d, vis, cmap) }
 }
 
-pub fn XftDrawRect(
-    d: XftDraw, color: &XftColor,
-    x: usize, y: usize, width: usize, height: usize
-) {
+pub fn XftDrawRect(d: XftDraw, color: &XftColor, x: usize, y: usize, width: usize, height: usize) {
     unsafe {
         xft::XftDrawRect(d, color, cast(x), cast(y), cast(width), cast(height));
     }
 }
 
 pub fn XftDrawGlyphs(
-    d: XftDraw, color: &XftColor, font: XftFont,
-    x: usize, y: usize, idx: &[c_uint]
+    d: XftDraw,
+    color: &XftColor,
+    font: XftFont,
+    x: usize,
+    y: usize,
+    idx: &[c_uint],
 ) {
     unsafe {
         xft::XftDrawGlyphs(
-            d, color, font, cast(x), cast(y), idx.as_ptr(), cast(idx.len())
+            d,
+            color,
+            font,
+            cast(x),
+            cast(y),
+            idx.as_ptr(),
+            cast(idx.len()),
         );
     }
 }
@@ -410,7 +491,9 @@ pub fn XftCharIndex(dpy: Display, font: XftFont, c: char) -> c_uint {
 }
 
 pub fn XftDrawChange(xft_draw: XftDraw, d: c_ulong) {
-    unsafe { xft::XftDrawChange(xft_draw, d); }
+    unsafe {
+        xft::XftDrawChange(xft_draw, d);
+    }
 }
 
 pub fn FcPatternDestroy(pattern: FcPattern) {
@@ -418,9 +501,13 @@ pub fn FcPatternDestroy(pattern: FcPattern) {
 }
 
 pub fn FcPatternDel(pattern: FcPattern, object: &CStr) {
-    unsafe { fc::FcPatternDel(pattern as _, object.as_ptr()); }
+    unsafe {
+        fc::FcPatternDel(pattern as _, object.as_ptr());
+    }
 }
 
 pub fn FcPatternAddInteger(pattern: FcPattern, object: &CStr, i: c_int) {
-    unsafe { fc::FcPatternAddInteger(pattern as _, object.as_ptr(), i); }
+    unsafe {
+        fc::FcPatternAddInteger(pattern as _, object.as_ptr(), i);
+    }
 }

--- a/src/x11_wrapper.rs
+++ b/src/x11_wrapper.rs
@@ -49,6 +49,7 @@ pub use xlib::ButtonPressMask as BUTTON_PRESS_MASK;
 pub use xlib::ButtonReleaseMask as BUTTON_RELEASE_MASK;
 pub use xlib::ExposureMask as EXPOSURE_MASK;
 pub use xlib::KeyPressMask as KEY_PRESS_MASK;
+pub use xlib::PointerMotionMask as POINTER_MOTION_MASK;
 pub use xlib::StructureNotifyMask as STRUCTURE_NOTIFY_MASK;
 pub use xlib::VisibilityChangeMask as VISIBILITY_CHANGE_MASK;
 
@@ -57,8 +58,12 @@ pub use xlib::KeyRelease as KEY_RELEASE;
 pub use xlib::Mod1Mask as MOD1_MASK;
 pub use xlib::XKeyEvent;
 
+pub use xlib::Button1;
 pub use xlib::ButtonPress as BUTTON_PRESS;
 pub use xlib::ButtonRelease as BUTTON_RELEASE;
+pub use xlib::ControlMask;
+pub use xlib::Mod4Mask;
+pub use xlib::ShiftMask;
 pub use xlib::XButtonEvent;
 
 pub use xlib::MotionNotify as MOTION_NOTIFY;
@@ -421,6 +426,22 @@ pub fn XConvertSelection(
 ) {
     unsafe {
         xlib::XConvertSelection(dpy, selection, target, property, requester, time);
+    }
+}
+
+pub fn XChangeWindowAttributes(
+    dpy: Display,
+    win: Window,
+    event_mask: u64,
+    mut attributes: XSetWindowAttributes,
+) {
+    unsafe {
+        xlib::XChangeWindowAttributes(
+            dpy,
+            win,
+            event_mask,
+            &mut attributes as *mut XSetWindowAttributes,
+        );
     }
 }
 

--- a/src/x11_wrapper.rs
+++ b/src/x11_wrapper.rs
@@ -119,7 +119,7 @@ pub fn cast_event<T>(event: &XEvent) -> &T {
 
 pub fn XOpenDisplay() -> Result<Display> {
     let dpy = unsafe { xlib::XOpenDisplay(null()) };
-    if dpy == null_mut() {
+    if dpy.is_null() {
         return Err("can't open display".into());
     }
     Ok(dpy)
@@ -145,6 +145,7 @@ pub fn XRootWindow(dpy: Display, scr: c_int) -> Window {
     unsafe { xlib::XRootWindow(dpy, scr) }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn XCreateWindow(
     dpy: Display,
     parent: Window,
@@ -249,6 +250,7 @@ pub fn XCloseDisplay(dpy: Display) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn XCopyArea(
     dpy: Display,
     src: c_ulong,
@@ -323,6 +325,7 @@ pub fn XLookupString(event: &mut XKeyEvent, buf: &mut [u8]) -> (KeySym, usize) {
     (ksym, cast(len))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn XGetWindowProperty(
     dpy: Display,
     win: Window,
@@ -355,6 +358,7 @@ pub fn XGetWindowProperty(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn XChangeProperty(
     dpy: Display,
     win: Window,
@@ -415,7 +419,7 @@ pub fn XConvertSelection(
 pub fn XftNameParse(name: &str) -> Result<FcPattern> {
     let name = CString::new(name).unwrap();
     let pattern = unsafe { xft::XftNameParse(name.as_ptr() as *const _) };
-    if pattern == null_mut() {
+    if pattern.is_null() {
         return Err("can't parse font name".into());
     }
     Ok(pattern)
@@ -424,7 +428,7 @@ pub fn XftNameParse(name: &str) -> Result<FcPattern> {
 pub fn XftFontMatch(dpy: Display, scr: c_int, pattern: FcPattern) -> Result<FcPattern> {
     let mut result = xft::FcResult::NoMatch;
     let pattern = unsafe { xft::XftFontMatch(dpy, scr, pattern, &mut result) };
-    if pattern == null_mut() {
+    if pattern.is_null() {
         return Err("can't match font".into());
     }
     Ok(pattern)
@@ -432,7 +436,7 @@ pub fn XftFontMatch(dpy: Display, scr: c_int, pattern: FcPattern) -> Result<FcPa
 
 pub fn XftFontOpenPattern(dpy: Display, pattern: FcPattern) -> Result<XftFont> {
     let font = unsafe { xft::XftFontOpenPattern(dpy, pattern) };
-    if font == null_mut() {
+    if font.is_null() {
         return Err("can't load font".into());
     }
     Ok(font)

--- a/src/x11_wrapper.rs
+++ b/src/x11_wrapper.rs
@@ -81,6 +81,7 @@ pub use xlib::XSelectionEvent;
 pub use xlib::ClientMessage as CLIENT_MESSAGE;
 pub use xlib::XClientMessageEvent;
 
+pub use x11::xrender::XRenderColor;
 pub use xft::XftColor;
 
 pub use fc::FC_SLANT_ITALIC;
@@ -457,6 +458,24 @@ pub fn XftColorAllocName(dpy: Display, vis: Visual, cmap: Colormap, name: &str) 
         xft::XftColorAllocName(dpy, vis, cmap, name.as_ptr(), col.as_mut_ptr());
         col.assume_init()
     }
+}
+
+pub fn XftColorAllocValue(
+    dpy: Display,
+    vis: Visual,
+    cmap: Colormap,
+    renderColor: &XRenderColor,
+) -> XftColor {
+    let mut col = mem::MaybeUninit::uninit();
+    unsafe {
+        xft::XftColorAllocValue(dpy, vis, cmap, renderColor, col.as_mut_ptr());
+        col.assume_init()
+    }
+}
+
+/// color MUST have been allocated by Xft (one of the XftColorAlloc... calls).
+pub unsafe fn XftColorFree(dpy: Display, vis: Visual, cmap: Colormap, mut color: XftColor) {
+    xft::XftColorFree(dpy, vis, cmap, &mut color as *mut XftColor);
 }
 
 pub fn XftDrawCreate(dpy: Display, d: c_ulong, vis: Visual, cmap: c_ulong) -> XftDraw {


### PR DESCRIPTION
Thanks for this, it is a great simple base to build on.  I started hacking on it for my own uses/future experiments and this PR has the following:
- 256 color
- true color
- osc codes started, primarily color related (most of the st codes and couple extras- missing the clipboard code from st).
- client mouse support
- alternate screen support

Also, it deviates a little from st.  I made foreground/background their own colors instead of just indexing one of the first 16.  This seems to be more like xterm and I think makes more sense if one is changing colors (vs having to just know which ones are magically fg/bg).  The OSC codes allow '?' in colors to query the current codes (was trivial to do).  If you do not want to deviate from st at all they should be easy to remove if you want the other stuff.

Sorry for the size, I also ran it through 'cargo fmt' so there is some whitespace noise as well (I can not really live without fmt anymore).  If you are interested in this cool, but either way thanks again for the work on this.  Having to do all that initial porting would probably have been a deal breaker for me.  I plan to do some more, I want to be able to replace st (st has been great but I want some pty/term code in rust I can play with in other projects) and then maybe extend it in a few controlled areas (not very 'suckless' I know).