### PR TITLE
Feature/cursor style

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use nix;
 use nix::errno::Errno;
 use nix::sys::select::{select, FdSet};
 use nix::sys::signal::{signal, SigHandler, Signal};
+use nix::sys::time::{TimeVal, TimeValLike};
 use std::fs::File;
 use std::io::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -83,7 +84,14 @@ impl App {
                 wfds.insert(pty_fd);
             }
 
-            match select(None, Some(&mut rfds), Some(&mut wfds), None, None) {
+            let mut timeout = TimeVal::milliseconds(500);
+            match select(
+                None,
+                Some(&mut rfds),
+                Some(&mut wfds),
+                None,
+                Some(&mut timeout),
+            ) {
                 Ok(_) => (),
                 Err(Errno::EINTR) => continue,
                 Err(err) => return Err(err.into()),

--- a/src/color.rs
+++ b/src/color.rs
@@ -11,5 +11,9 @@ pub const COLOR_NAMES: &[&str] = &[
 
 pub const FG_COLOR: usize = 258;
 pub const BG_COLOR: usize = 259;
+pub const CURSOR_COLOR: usize = 256;
+pub const CURSOR_REV_COLOR: usize = 257;
 pub const FG_COLOR_NAME: &str = "grey90";
 pub const BG_COLOR_NAME: &str = "black";
+pub const CURSOR_COLOR_NAME: &str = "#cccccc";
+pub const CURSOR_REV_COLOR_NAME: &str = "#555555";

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,9 +1,16 @@
-use crate::glyph::{blank_glyph, Glyph};
 use std::mem;
 
 #[derive(Clone, Copy, Debug)]
+pub enum CursorMode {
+    Block,
+    Underline,
+    Bar,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct Cursor {
-    pub glyph: Glyph,
+    pub mode: CursorMode,
+    pub blink: bool,
     pub x: usize,
     pub y: usize,
     // When cursor is at the right edge of the terminal, it does
@@ -14,7 +21,8 @@ pub struct Cursor {
 impl Cursor {
     pub fn new() -> Self {
         Cursor {
-            glyph: blank_glyph(),
+            mode: CursorMode::Block,
+            blink: false,
             wrap_next: false,
             x: 0,
             y: 0,

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,5 +1,9 @@
 use crate::app::app_exit;
-use crate::color::{BG_COLOR, BG_COLOR_NAME, FG_COLOR_NAME};
+use crate::color::{
+    BG_COLOR, BG_COLOR_NAME, CURSOR_COLOR, CURSOR_COLOR_NAME, CURSOR_REV_COLOR,
+    CURSOR_REV_COLOR_NAME, FG_COLOR_NAME,
+};
+use crate::cursor::CursorMode;
 use crate::font::Font;
 use crate::glyph::{GlyphAttr, GlyphProp};
 use crate::keymap::map_key;
@@ -37,6 +41,11 @@ bitflags! {
 
 // FIXME, this can only be 0 until impemented everywhere.
 const BORDERPX: u16 = 0;
+
+/*
+ * thickness of underline and bar cursors
+ */
+const CURSORTHICKNESS: usize = 2;
 
 const FORCEMOUSEMOD: u32 = x11::ShiftMask;
 
@@ -94,7 +103,7 @@ impl Win {
         let (width, height) = (cols * cw, rows * ch);
 
         let cmap = x11::XDefaultColormap(dpy, scr);
-        let mut colors = Vec::with_capacity(257); //COLOR_NAMES.len());
+        let mut colors = Vec::with_capacity(260);
         for i in 0..=255 {
             colors.push(
                 x11::xloadcolor(dpy, vis, cmap, i, None).expect("Failed to load a default color!"),
@@ -102,12 +111,12 @@ impl Win {
         }
         // cursor
         colors.push(
-            x11::xloadcolor(dpy, vis, cmap, 256, Some("#cccccc"))
+            x11::xloadcolor(dpy, vis, cmap, 256, Some(CURSOR_COLOR_NAME))
                 .expect("Failed to load a default color!"),
         );
         // reverse cursor
         colors.push(
-            x11::xloadcolor(dpy, vis, cmap, 257, Some("#555555"))
+            x11::xloadcolor(dpy, vis, cmap, 257, Some(CURSOR_REV_COLOR_NAME))
                 .expect("Failed to load a default color!"),
         );
         // foreground
@@ -276,11 +285,19 @@ impl Win {
             }
         }
         // cursor
-        if let Ok(color) = x11::xloadcolor(self.dpy, self.vis, self.cmap, 256, Some("#cccccc")) {
+        if let Ok(color) =
+            x11::xloadcolor(self.dpy, self.vis, self.cmap, 256, Some(CURSOR_COLOR_NAME))
+        {
             self.colors.push(color);
         }
         // reverse cursor
-        if let Ok(color) = x11::xloadcolor(self.dpy, self.vis, self.cmap, 257, Some("#555555")) {
+        if let Ok(color) = x11::xloadcolor(
+            self.dpy,
+            self.vis,
+            self.cmap,
+            257,
+            Some(CURSOR_REV_COLOR_NAME),
+        ) {
             self.colors.push(color);
         }
         // foreground
@@ -333,8 +350,43 @@ impl Win {
         }
 
         if !self.mode.contains(WinMode::HIDE) {
-            let (x, y, g) = term.get_glyph_at_cursor();
-            self.draw_cells(&[g.c], g.prop, x * self.cw, y * self.ch);
+            let (x, y) = (term.c.x, term.c.y);
+            match term.c.mode {
+                CursorMode::Block => {
+                    let g = term.get_glyph_at_cursor();
+                    self.draw_cells(&[g.c], g.prop, x * self.cw, y * self.ch);
+                }
+                CursorMode::Underline => {
+                    let drawcol = if term.is_selected(x, y) {
+                        self.colors[CURSOR_REV_COLOR]
+                    } else {
+                        self.colors[CURSOR_COLOR]
+                    };
+                    x11::XftDrawRect(
+                        self.draw,
+                        &drawcol,
+                        BORDERPX as usize + x * self.cw,
+                        BORDERPX as usize + (y + 1) * self.ch - CURSORTHICKNESS,
+                        self.cw,
+                        CURSORTHICKNESS,
+                    );
+                }
+                CursorMode::Bar => {
+                    let drawcol = if term.is_selected(x, y) {
+                        self.colors[CURSOR_REV_COLOR]
+                    } else {
+                        self.colors[CURSOR_COLOR]
+                    };
+                    x11::XftDrawRect(
+                        self.draw,
+                        &drawcol,
+                        BORDERPX as usize + x * self.cw,
+                        BORDERPX as usize + y * self.ch,
+                        CURSORTHICKNESS,
+                        self.ch,
+                    );
+                }
+            }
         }
 
         self.finish_draw(term.cols, term.rows);

--- a/src/win.rs
+++ b/src/win.rs
@@ -52,6 +52,7 @@ const FORCEMOUSEMOD: u32 = x11::ShiftMask;
 pub struct Win {
     visible: bool,
     mode: WinMode,
+    cursor_vis: bool,
 
     dpy: x11::Display,
     win: x11::Window,
@@ -194,6 +195,7 @@ impl Win {
         Ok(Win {
             visible: true,
             mode: WinMode::empty(),
+            cursor_vis: true,
 
             sel_type,
             sel_snap: Snap::new(),
@@ -349,7 +351,12 @@ impl Win {
             term.dirty[y] = false;
         }
 
-        if !self.mode.contains(WinMode::HIDE) {
+        if term.c.blink {
+            self.cursor_vis = !self.cursor_vis;
+        } else {
+            self.cursor_vis = true;
+        }
+        if !self.mode.contains(WinMode::HIDE) && self.cursor_vis {
             let (x, y) = (term.c.x, term.c.y);
             match term.c.mode {
                 CursorMode::Block => {


### PR DESCRIPTION
Added cursor style support with blinking (CSI P SPC q).  Also OSC 12 and 112 to set/reset the cursor color.  Note that blinking and OSC 12/112 are extensions to st.  The blinking was pretty trivial and seems like it should be there if requested.

The reformatting around the comments in vte was because of a bug in rust fmt, it could not handle the code commented that way for some reason and refused to work.