### PR TITLE
Feature/bug and version

### DIFF
--- a/src/vte.rs
+++ b/src/vte.rs
@@ -634,6 +634,8 @@ impl<'a> Perform for Performer<'a> {
                 .unwrap_or(default)
         };
 
+        // FIXME? i
+        // FIXME c
         match (action, intermediate) {
             // ICH -- Insert <n> blank char
             ('@', None) => term.insert_blanks(arg0_or(1)),

--- a/src/vte.rs
+++ b/src/vte.rs
@@ -9,6 +9,9 @@ use crate::win::{Win, WinMode};
 use std::iter;
 use vte::{Params, ParamsIter, Parser, Perform};
 
+const NAME: &str = env!("CARGO_PKG_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub struct Vte {
     parser: Parser,
     last_c: Option<char>,
@@ -635,7 +638,6 @@ impl<'a> Perform for Performer<'a> {
         };
 
         // FIXME? i
-        // FIXME c
         match (action, intermediate) {
             // ICH -- Insert <n> blank char
             ('@', None) => term.insert_blanks(arg0_or(1)),
@@ -768,6 +770,18 @@ impl<'a> Perform for Performer<'a> {
             ('X', None) => term.clear_region(term.c.x..term.c.x + arg0_or(1), iter::once(term.c.y)),
             // CBT -- Cursor Backward Tabulation <n> tab stops
             ('Z', None) => term.put_tabs(-(arg0_or(1) as i32)),
+            // XTVERSION -- Return the terminal name/version
+            ('q', Some(b'>')) => {
+                if let Some(arg0) = arg0 {
+                    if arg0.get(0) == Some(&0) {
+                        self.term.pty.write(
+                            format!("\x1bP>|{} {}\x1b\\", NAME, VERSION)
+                                .as_bytes()
+                                .to_vec(),
+                        );
+                    }
+                }
+            }
             // DECSCUSR -- Set Cursor Style
             ('q', Some(b' ')) => {
                 if let Some(arg0) = arg0 {

--- a/src/win.rs
+++ b/src/win.rs
@@ -406,6 +406,10 @@ impl Win {
         self.draw(term);
     }
 
+    pub fn is_pending(&self) -> bool {
+        x11::XPending(self.dpy) > 0
+    }
+
     pub fn process_input(&mut self, term: &mut Term) {
         while x11::XPending(self.dpy) > 0 {
             let mut xev = x11::XNextEvent(self.dpy);


### PR DESCRIPTION
Getting close to parity with st features!  This one fixes a bug where every so often a char would not come through until a second char was entered.  From looking at st and googling it seems that X could sometimes get an event outside the main loop select and then select would not see the X fd as being ready.  It checks XPending now and sets a 0 timeout if more then 0 and also just tries to process the x events (since it uses xpending this should not block) to fix this.  Basically what st does.  You can make the cursor blink in sync to pressing shift (or some other key) but not sure fixing that is worth all the code to track the timings, etc.

Also adds the XTVERSION CSI code, I noticed both tmux and neovim trying to use this code and it seems useful (even if nothing will know what rterm is...).  I might want to use it in the future myself, my main open source work involves a shell which leads to a line editor and the underlying console code and wanting to experiment with PTYs/terminals to support that stuff is what brought me here so having a standard code to detect rterm is a good thing.

I think I might start trying to use rterm under tmux instead of st now and see how that works out.  It has been holding up good in quick testing.