### PR TITLE
Revert commit to not make bold use bright colors, this was a mistake.

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -775,7 +775,10 @@ impl Win {
     }
 
     fn draw_cells(&self, cs: &[char], prop: GlyphProp, xp: usize, yp: usize) {
-        let GlyphProp { fg, bg, attr } = prop;
+        let GlyphProp { mut fg, bg, attr } = prop;
+        if attr.contains(GlyphAttr::BOLD) && fg < 8 {
+            fg += 8;
+        }
         let charlen = if attr.contains(GlyphAttr::WIDE) {
             cs.len() * 2
         } else {


### PR DESCRIPTION
I tried to push this direct (clean repo with ssh url) and do not have permission, the error is:
ERROR: Permission to mechpen/rterm.git denied to sstanfield.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

This reverts my bad patch for bold colors.