### PR TITLE
Add XIM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "rterm"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A port of [suckless terminal](https://st.suckless.org/) to rust.
 
 Most functions of `st` are implemented.  A few `st` features are missing:
 
-- XIM support
 - wide-char support
 
 Licensed with MIT or Apache-2.0


### PR DESCRIPTION
This allows use of composed characters in Xorg as well as use of external IMEs. Restarting the IME is not currently supported (if an IME is detected on startup, rterm will stop reading input if it exits).

I mainly wanted support for the compose key, but went down the rabbit hole of figuring out how external IMEs work (and debugging an incorrect use of `XFilterEvent` in `rterm`), so it seems to work with them too (I've tried `scim` and `fcitx5`).

It doesn't currently detect when the external IME exits/crashes, so `rterm` will simply stop accepting input if this happens. I can't really see how to implement this part properly, and the original `st` seems to crash in this scenario (with a `BadWindow` error).