### PR TITLE
Make this build on NetBSD/macppc specifically, and hopefully...

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -706,7 +706,7 @@ impl Win {
                 return;
             }
 
-            let len = (nitems * (format as u64) / 8) as usize;
+            let len = ((nitems * (format as u32)) / 8) as usize;
             let buf = unsafe { slice::from_raw_parts(data, len) };
             self.term_write(term, pty, buf);
             x11::XFree(data as *mut _);
@@ -714,7 +714,7 @@ impl Win {
             if rem == 0 {
                 break;
             } else {
-                ofs += (nitems * (format as u64) / 32) as i64;
+                ofs += ((nitems * (format as u32)) / 32) as c_long;
             }
         }
     }

--- a/src/x11_wrapper.rs
+++ b/src/x11_wrapper.rs
@@ -481,7 +481,7 @@ pub fn XConvertSelection(
 pub fn XChangeWindowAttributes(
     dpy: Display,
     win: Window,
-    event_mask: u64,
+    event_mask: c_ulong,
     mut attributes: XSetWindowAttributes,
 ) {
     unsafe {


### PR DESCRIPTION
...improve portability to 32-bit ports:

 * Avoid trying to do `u64 * u32`, as rust may not implement that on 32-bit ports (it doesn't on 32-bit powerpc).
 * Fix type mismatch between variable and funciton parameter.
 * Fix XChangeWindowAttributes parameter declaration to match (u64 -> c_ulong).